### PR TITLE
Extra method added to remove rows for models

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,9 @@ use Mgussekloo\FacetFilter\Indexer;
 $products = Product::with(['sizes'])->get(); // get some products
 
 $indexer = new Indexer();
-$indexer->resetIndex(); // clears the index
+$indexer->resetIndex(); // clears the entire index
+or
+$indexer->resetRows($products); // clears the index for the provided models
 $indexer->buildIndex($products); // process the models
 ```
 

--- a/src/Indexer.php
+++ b/src/Indexer.php
@@ -3,6 +3,7 @@
 namespace Mgussekloo\FacetFilter;
 
 use DB;
+use Illuminate\Database\Eloquent\Model;
 use Mgussekloo\FacetFilter\Facades\FacetFilter;
 use Mgussekloo\FacetFilter\Models\FacetRow;
 
@@ -27,6 +28,24 @@ class Indexer
     public function insertRows($rows)
     {
         return FacetRow::insert(array_values($rows));
+    }
+
+    public function resetRows($models = null): self
+    {
+        if (is_null($models) || $models->isEmpty()) {
+            return $this->resetIndex();
+        }
+
+        foreach ($models as $model) {
+            FacetFilter::getFacets($model::class)->each(function ($facet) use ($model) {
+                DB::table('facetrows')
+                    ->where('subject_id', $model->{$model->getKeyName()})
+                    ->where('facet_slug', $facet->getSlug())
+                    ->delete();
+            });
+        }
+
+        return $this;
     }
 
     public function resetIndex()


### PR DESCRIPTION
You can chain resetRows($myModels) to the indexer call and only remove records that are related to those models. This prevents removing the entire index and rebuilding it.